### PR TITLE
add livestreaminputhealth_v1 proto

### DIFF
--- a/video/live-stream-input-health/README.md
+++ b/video/live-stream-input-health/README.md
@@ -1,0 +1,13 @@
+<p align="center">
+  <a href="https://mux.com/">
+    <img src="https://avatars.githubusercontent.com/u/16199997?s=200&v=4" alt="Mux Logo">
+  </a>
+</p>
+
+# Mux Video Live Stream Input Health Event Stream
+
+Mux can now stream livestream health and metadata events for customers to an Amazon Kinesis endpoint in the customer’s cloud account. This feature is currently in closed beta for customers interested in testing the feature.
+
+`LiveStreamInputHealth` events are sent to Kinesis as they are emitted and are made available to customers to retrieve from the stream within about one minute. Each `LiveStreamInputHealth` event will contain details for either a `RTMPMetadataEvent` or `HealthUpdateEvent`. Protobuf definitions for consuming the livestream input health events are in `proto/v1/livestreaminputhealth_v1.proto`.
+
+This spec also supports Google Pub/Sub Schema requirements ([here](https://cloud.google.com/pubsub/docs/schemas#schema_types)) for future consumption with Pub/Sub.

--- a/video/live-stream-input-health/proto/v1/livestreaminputhealth_v1.proto
+++ b/video/live-stream-input-health/proto/v1/livestreaminputhealth_v1.proto
@@ -7,7 +7,6 @@ option go_package = "github.com/muxinc/mux-protobuf/livestreaminputhealth_v1";
 // The top level message that customers will receive.
 
 message LiveStreamInputHealth {
-
   // The generic live health events
 
   message AudioTrack {

--- a/video/live-stream-input-health/proto/v1/livestreaminputhealth_v1.proto
+++ b/video/live-stream-input-health/proto/v1/livestreaminputhealth_v1.proto
@@ -1,0 +1,67 @@
+syntax = "proto2";
+
+package livestreaminputhealth.v1;
+
+option go_package = "github.com/muxinc/mux-protobuf/livestreaminputhealth_v1";
+
+// The top level message that customers will receive.
+
+message LiveStreamInputHealth {
+
+  // The generic live health events
+
+  message AudioTrack {
+    optional uint64 bytes_received = 1;
+  }
+  message VideoTrack {
+    optional uint64 stream_start_ms = 1;
+    optional uint64 stream_end_ms = 2;
+    optional uint64 bytes_received = 3;
+    optional uint64 keyframes_received = 4;
+    optional uint64 total_frames_received = 5;
+  }
+  message CaptionTrack {
+    optional uint64 bytes_received = 1;
+    optional uint32 channel_count = 2;
+  }
+  message HealthUpdateEvent {
+    required string environment_id = 1;
+    required string live_stream_id = 2;
+    required string asset_id = 3;
+    optional uint64 measurement_start_ms = 4;
+    optional uint64 measurement_end_ms = 5;
+    repeated VideoTrack video_tracks = 7;
+    repeated AudioTrack audio_tracks = 8;
+    repeated CaptionTrack caption_tracks = 9;
+  }
+
+  // RTMP specific metadata messages
+
+  message RTMPVideoTrackMetadata {
+    optional string codec_id = 1;
+    optional double data_rate = 2;
+    optional double frame_rate = 3;
+    optional double height = 4;
+    optional double width = 5;
+  }
+  message RTMPAudioTrackMetadata {
+    optional string codec_id = 1;
+    optional double data_rate = 2;
+    optional double channel_count = 3;
+    optional double sample_rate = 4;
+    optional double sample_size = 5;
+  }
+  message RTMPMetadataEvent {
+    required string environment_id = 1;
+    required string live_stream_id = 2;
+    required string asset_id = 3;
+    optional uint64 received_time_ms = 4;
+    optional string encoder = 5;
+    optional RTMPVideoTrackMetadata video_track = 6;
+    optional RTMPAudioTrackMetadata audio_track = 7;
+  }
+  oneof event {
+    RTMPMetadataEvent rtmp_metadata_event = 1;
+    HealthUpdateEvent health_update_event = 2;
+  }
+}


### PR DESCRIPTION
## WARNING THIS IS A PUBLIC REPO
Reminder, this repo is **public**, discussion of unreleased features or internal details should happen outside of this repo.


#### Summary

- [x] Confirmed the contents of this PR can be public
- [x] Verified no breaking changes

#### Description of change

Adds v1 of live stream input health proto for Live Stream Input Health Event Stream
