### PR TITLE
Add non-fatal error and ad metrics fields

### DIFF
--- a/video_view/README.md
+++ b/video_view/README.md
@@ -14,15 +14,41 @@ See our [Streaming Exports guide](https://docs.mux.com/guides/data/export-raw-vi
 
 As Mux Data adds new metrics, new versions of the protobuf specification are released. This repository always contains the most up-to-date specification. See our guide on [understanding the data fields](https://docs.mux.com/guides/data/export-raw-video-view-data#understand-the-data-fields) to see a full list of supported metrics.
 
+### Version 9
+
+Added new dimensions:
+
+- `playback_failure_error_type_id`
+- `playback_business_exception_error_type_id`
+- `video_startup_business_exception_error_type_id`
+
+Added new event metadata for error events (`player_error_severity` and `player_error_is_business_exception`)
+
+### Version 8
+
+Added new metrics:
+
+- `ad_attempt_count`
+- `ad_break_count`
+- `ad_break_error_count`
+- `ad_break_error_percentage`
+- `ad_error_count`
+- `ad_error_percentage`
+- `ad_impression_count`
+- `ad_startup_error_count`
+- `ad_startup_error_percentage`
+- `ad_exit_before_start_count`
+- `ad_exit_before_start_percentage`
+
 ### Version 7
 
-Added new metric:
+Added new dimension:
 
 - `video_startup_failure`
 
 ### Version 6
 
-Added new metric:
+Added new dimension:
 
 - `view_has_ad`
 
@@ -36,19 +62,22 @@ Added new event metadata for `ad` (`adplay`, `adplaying`, etc) and `error` event
 
 ### Version 3
 
-Added new metrics:
+Added new dimensions:
 
 - `custom_6`
 - `custom_7`
 - `custom_8`
 - `custom_9`
 - `custom_10`
-- `view_dropped_frame_count`
 - `view_drm_type`
+
+Added new metric:
+
+- `view_dropped_frame_count`
 
 ### Version 2
 
-Added new metric:
+Added new dimension:
 
 - `mux_embed`
 

--- a/video_view/v1/video_view.proto
+++ b/video_view/v1/video_view.proto
@@ -39,6 +39,8 @@ message VideoView {
     optional string error_code = 2;
     optional string error_message = 3;
     optional string error_context = 4;
+    optional string error_severity = 5;
+    optional bool is_business_exception = 6;
   }
 
   // Ad Info

--- a/video_view/v1/video_view.proto
+++ b/video_view/v1/video_view.proto
@@ -231,6 +231,7 @@ message VideoView {
   optional string environment_id = 120;
   optional string viewer_device_model = 121;
   optional string mux_embed = 122;
+  // new custom fields
   optional string custom_6 = 123;
   optional string custom_7 = 124;
   optional string custom_8 = 125;
@@ -240,5 +241,21 @@ message VideoView {
   optional int32 view_dropped_frame_count = 129;
   optional bool view_has_ad = 130;
   optional bool video_startup_failure = 131;
+  // ad metrics v2
+  optional int32 ad_attempt_count = 132;
+  optional int32 ad_break_count = 133;
+  optional int32 ad_break_error_count = 134;
+  optional float ad_break_error_percentage = 135;
+  optional int32 ad_error_count = 136;
+  optional float ad_error_percentage = 137;
+  optional int32 ad_impression_count = 138;
+  optional int32 ad_startup_error_count = 139;
+  optional float ad_startup_error_percentage = 140;
+  optional int32 ad_exit_before_start_count = 141;
+  optional float ad_exit_before_start_percentage = 142;
+  // non-fatal errors
+  optional int32 playback_failure_error_type_id = 143;
+  optional int32 playback_business_exception_error_type_id = 144;
+  optional int32 video_startup_business_exception_error_type_id = 145;
   reserved 200 to 299;
 }


### PR DESCRIPTION
#### Summary

- [x] Confirmed the contents of this PR can be public
- [x] Verified no breaking changes

#### Description of change

Adds new V8 ad metric fields and V9 non-fatal error fields.
