### PR TITLE
Adding `view_session_id` and `player_error_code` to monitoring samples

### DIFF
--- a/monitoring_samples/v1/monitoring_samples.proto
+++ b/monitoring_samples/v1/monitoring_samples.proto
@@ -46,6 +46,10 @@ message Sample {
   optional string sub_property_id = 18;
   // Stream Type (VOD/Live)
   optional string stream_type = 19;
+  // View Session ID
+  optional string view_session_id = 20;
+  // Player Error Code
+  optional string player_error_code = 21;
 }
 
 message Record {


### PR DESCRIPTION
#### Summary

- [x] Confirmed the contents of this PR can be public
- [x] Verified no breaking changes

#### Description of change

Adding `view_session_id` and `player_error_code` to monitoring samples