### PR TITLE
add view_dropped dimension

### DIFF
--- a/video_view/README.md
+++ b/video_view/README.md
@@ -14,6 +14,12 @@ See our [Streaming Exports guide](https://docs.mux.com/guides/data/export-raw-vi
 
 As Mux Data adds new metrics, new versions of the protobuf specification are released. This repository always contains the most up-to-date specification. See our guide on [understanding the data fields](https://docs.mux.com/guides/data/export-raw-video-view-data#understand-the-data-fields) to see a full list of supported metrics.
 
+### Version 11
+
+Added new dimension:
+
+- `view_dropped`
+
 ### Version 10
 
 Added new dimension:

--- a/video_view/v1/video_view.proto
+++ b/video_view/v1/video_view.proto
@@ -265,5 +265,7 @@ message VideoView {
   optional int32 ad_preroll_startup_time = 148;
   optional int32 ad_playing_time = 149;
   optional int32 view_content_playing_time = 150;
+  // view dropped dimension
+  optional bool view_dropped = 151;
   reserved 200 to 299;
 }


### PR DESCRIPTION


#### Summary

- [x] Confirmed the contents of this PR can be public
- [X] Verified no breaking changes

#### Description of change

Adding new exportable dimension view_dropped to schema v11 for video_view
