### PR TITLE
Adds new fields to support CDN change events.

### DIFF
--- a/monitoring_samples/v1/monitoring_samples.proto
+++ b/monitoring_samples/v1/monitoring_samples.proto
@@ -50,6 +50,7 @@ message Sample {
   optional string view_session_id = 20;
   // Player Error Code
   optional string player_error_code = 21;
+  optional Source previous_source = 22;
 }
 
 message Record {

--- a/playback_event/README.md
+++ b/playback_event/README.md
@@ -9,6 +9,7 @@
 Events are activities that happen during the course of a video view. A comprehensive list of events is available in the [Mux Data Docs](https://docs.mux.com/guides/data/mux-playback-events). Note that you may receive events not mentioned in the documentation.
 
 Each event will include the following details:
+
 - Type (name of event)
 - Event sequence number
 - Server time (timestamp of when the event was received by Mux servers)
@@ -17,11 +18,10 @@ Each event will include the following details:
 - One of the following additional details:
   - Device orientation info, in the case of an ‘orientationchange’ event
   - Rendition info, in the case of a ‘renditionchange’ event
-
+  - CDNChange info, in the case of a ‘cdnchange’ event
 
 ### Version 1
 
 [Proto v1](v1/playback_event.proto)
 
 Version 1 Playback Event proto spec.
-

--- a/playback_event/v1/playback_event.proto
+++ b/playback_event/v1/playback_event.proto
@@ -24,6 +24,12 @@ message PlaybackEvent {
     required string type = 4;
     optional OrientationInfo orientation_info = 5;
     optional RenditionInfo rendition_info = 6;
+    optional ErrorInfo error_info = 8;
+    optional AdInfo ad_info = 9;
+    optional RequestFailedInfo request_failed_info = 10;
+    optional RequestCanceledInfo request_canceled_info = 11;
+    optional RequestCompletedInfo request_completed_info = 12;
+    optional CdnChangeInfo cdn_change_info = 13;
   }
 
   // Device orientation info
@@ -39,6 +45,67 @@ message PlaybackEvent {
     optional int64 height = 2;
     optional double fps = 3;
     optional int64 bitrate = 4;
+    optional string codec = 5;
+    optional string rendition_name = 6;
+  }
+
+  // Error Info
+  message ErrorInfo {
+    optional string error_type = 1;
+    optional string error_code = 2;
+    optional string error_message = 3;
+    optional string error_context = 4;
+    optional string error_severity = 5;
+    optional bool is_business_exception = 6;
+  }
+
+  // Ad Info
+  message AdInfo {
+    optional string ad_asset_url = 1;
+    optional string ad_tag_url = 2;
+    optional string ad_creative_id = 3;
+    optional string ad_id = 4;
+    optional string ad_universal_id = 5;
+  }
+
+  message RequestFailedInfo {
+    optional string request_url = 1;
+    optional string request_hostname = 2;
+    optional string request_type = 3;
+    optional string request_error = 4;
+    optional int64 request_error_code = 5;
+    optional string request_error_text = 6;
+    optional string request_id = 7;
+  }
+
+  message RequestCanceledInfo {
+    optional string request_url = 1;
+    optional string request_hostname = 2;
+    optional string request_type = 3;
+    optional string request_cancel = 4;
+  }
+
+  message RequestCompletedInfo {
+    optional string request_url = 1;
+    optional string request_hostname = 2;
+    optional string request_type = 3;
+    optional int64 request_start = 4;
+    optional int64 request_response_start = 5;
+    optional int64 request_response_end = 6;
+    optional int64 request_bytes_loaded = 7;
+    optional string request_labeled_bitrate = 8;
+    optional string request_id = 9;
+    optional int64 request_current_level = 10;
+    optional int64 request_media_duration = 11;
+    optional int64 request_video_width = 12;
+    optional int64 request_video_height = 13;
+    optional int64 request_media_start_time = 14;
+  }
+
+  // CDN change info
+  message CdnChangeInfo {
+    optional string video_cdn = 1;
+    optional string video_previous_cdn = 2;
   }
   required string id = 83;
   required string view_id = 1;
@@ -125,4 +192,5 @@ message PlaybackEvent {
   repeated Event events = 82;
   optional string user_agent_crawler_class = 84;
   optional string data_center_crawler_name_code = 85;
+  optional string player_error_context = 86;
 }

--- a/video_view/README.md
+++ b/video_view/README.md
@@ -14,6 +14,14 @@ See our [Streaming Exports guide](https://docs.mux.com/guides/data/export-raw-vi
 
 As Mux Data adds new metrics, new versions of the protobuf specification are released. This repository always contains the most up-to-date specification. See our guide on [understanding the data fields](https://docs.mux.com/guides/data/export-raw-video-view-data#understand-the-data-fields) to see a full list of supported metrics.
 
+### Version 14
+
+Added new standard dimensions:
+
+- `video_cdn_trace`
+
+Added new event metadata for `cdnchange` events
+
 ### Version 13
 
 Added new standard dimensions:

--- a/video_view/v1/video_view.proto
+++ b/video_view/v1/video_view.proto
@@ -86,6 +86,12 @@ message VideoView {
     optional int64 request_media_start_time = 14;
   }
 
+  // CDN change info
+  message CdnChangeInfo {
+    optional string video_cdn = 1;
+    optional string video_previous_cdn = 2;
+  }
+
   message Event {
     required uint64 sequence_number = 7;
     required Timestamp server_time = 1;
@@ -99,6 +105,7 @@ message VideoView {
     optional RequestFailedInfo request_failed_info = 10;
     optional RequestCanceledInfo request_canceled_info = 11;
     optional RequestCompletedInfo request_completed_info = 12;
+    optional CdnChangeInfo cdn_change_info = 13;
   }
 
   required string view_id = 1;
@@ -265,9 +272,7 @@ message VideoView {
   optional int32 ad_preroll_startup_time = 148;
   optional int32 ad_playing_time = 149;
   optional int32 view_content_playing_time = 150;
-  // view dropped dimension
   optional bool view_dropped = 151;
-  // new custom fields
   optional string custom_11 = 152;
   optional string custom_12 = 153;
   optional string custom_13 = 154;
@@ -278,7 +283,6 @@ message VideoView {
   optional string custom_18 = 159;
   optional string custom_19 = 160;
   optional string custom_20 = 161;
-  // new standard dimensions
   optional bool used_captions = 162; // Boolean indicating if the player used captions during the view
   optional bool used_pip = 163; // Boolean indicating if the player used Picture in Picture during the view
   optional string video_affiliate = 164; // Affiliate that the viewer is watching or referred the viewer
@@ -296,5 +300,6 @@ message VideoView {
   optional string viewer_plan_category = 176; // Category of the viewer's customer-specific subscription plan
   optional string viewer_plan_status = 177; // Status of the viewer's customer-specific subscription plan
   optional string video_creator_id = 178; // String ID of the creator of the video, provided by Mux Video
+  repeated string video_cdn_trace = 179; // List of video delivery CDN values, in order seen during the view. Values may be repeated
   reserved 200 to 299;
 }


### PR DESCRIPTION
- Add new cdnchange event to playback_event and video_view schemas.
- Add video_cdn_trace field to video_view schema.
- Add previous_source to monitoring_samples schema.

## WARNING THIS IS A PUBLIC REPO
Reminder, this repo is **public**, discussion of unreleased features or internal details should happen outside of this repo.


#### Summary

- [x] Confirmed the contents of this PR can be public
- [x] Verified no breaking changes

#### Description of change

<!--- Add a short description of the changes involved. --->
