### PR TITLE
Video View V16 Fields

### DIFF
--- a/video_view/README.md
+++ b/video_view/README.md
@@ -14,6 +14,26 @@ See our [Streaming Exports guide](https://docs.mux.com/guides/data/export-raw-vi
 
 As Mux Data adds new metrics, new versions of the protobuf specification are released. This repository always contains the most up-to-date specification. See our guide on [understanding the data fields](https://docs.mux.com/guides/data/export-raw-video-view-data#understand-the-data-fields) to see a full list of supported metrics.
 
+### Version 16
+
+Added new rendition dimensions:
+
+- `player_height_initial`
+- `player_source_bitrate_initial`
+- `player_source_fps_initial`
+- `player_width_initial`
+- `audio_codec_initial`
+- `video_codec_initial`
+- `video_dynamic_range_type_initial`
+- `player_source_bitrate`
+- `player_source_fps`
+
+and new rendition metrics:
+
+- `view_rendition_change_count`
+- `view_rendition_upshift_count`
+- `view_rendition_downshift_count`
+
 ### Version 15
 
 Added new playing time metrics, with playing time calculated per playback mode and ad type:

--- a/video_view/v1/video_view.proto
+++ b/video_view/v1/video_view.proto
@@ -310,5 +310,17 @@ message VideoView {
   optional string player_playback_mode_data = 181; // Additional metadata associated with the current playback mode. This can contain JSON-encoded data or other contextual information about the playback mode state.
   map<string, PlayingTimeInfo> playback_mode_totals = 182; // Map of total playing time and event count per playback mode for the view. Example format {"fullscreen":{"total_playing_time_ms":60000},"multiview":{"total_playing_time_ms":30000}}
   map<string, PlayingTimeInfo> ad_type_totals = 183; // Map of total ad playing time and event count per ad type for the view. Example format {"preroll":{"total_playing_time_ms":30000},"midroll":{"total_playing_time_ms":15000}}
+  optional int32 view_rendition_change_count = 184; // The total number of rendition changes that occurred during playback, including both upshifts and downshifts in quality.
+  optional int32 view_rendition_upshift_count = 185; // The number of times the video quality shifted upward to a higher quality rendition during playback.
+  optional int32 view_rendition_downshift_count = 186; // The number of times the video quality shifted downward to a lower quality rendition during playback.
+  optional int32 player_height_initial = 187; // Initial height of the player (in pixels) as displayed on the screen.
+  optional int32 player_source_bitrate_initial = 188; // Initial bitrate of the source video.
+  optional float player_source_fps_initial = 189; // Initial framerate of the source video.
+  optional int32 player_width_initial = 190; // Initial width of the player (in pixels) as displayed on the screen.
+  optional string audio_codec_initial = 191; // Initial codec of the audio that played.
+  optional string video_codec_initial = 192; // Initial codec of the video that played.
+  optional string video_dynamic_range_type_initial = 193; // Initial format or type of dynamic range available on the video that played
+  optional int32 player_source_bitrate = 194; // Bitrate of the source video.
+  optional float player_source_fps = 195; // Framerate of the source video.
   reserved 200 to 299;
 }


### PR DESCRIPTION
#### Summary

- [x] Confirmed the contents of this PR can be public
- [x] Verified no breaking changes

#### Description of change

Added new fields to the Video Views protobuf definition file.

New rendition dimensions:

- `player_height_initial`
- `player_source_bitrate_initial`
- `player_source_fps_initial`
- `player_width_initial`
- `audio_codec_initial`
- `video_codec_initial`
- `video_dynamic_range_type_initial`
- `player_source_bitrate`
- `player_source_fps`

and new rendition metrics:

- `view_rendition_change_count`
- `view_rendition_upshift_count`
- `view_rendition_downshift_count`
