### PR TITLE
Update protobuf to v17

### DIFF
--- a/playback_event/README.md
+++ b/playback_event/README.md
@@ -19,6 +19,8 @@ Each event will include the following details:
   - Device orientation info, in the case of an ‘orientationchange’ event
   - Rendition info, in the case of a ‘renditionchange’ event
   - CDNChange info, in the case of a ‘cdnchange’ event
+  - PlaybackModeChange info, in the case of a ‘playbackmodechange’ event
+  - NetworkChange info, in the case of a ‘networkchange’ event
 
 ### Version 1
 

--- a/playback_event/v1/playback_event.proto
+++ b/playback_event/v1/playback_event.proto
@@ -30,6 +30,8 @@ message PlaybackEvent {
     optional RequestCanceledInfo request_canceled_info = 11;
     optional RequestCompletedInfo request_completed_info = 12;
     optional CdnChangeInfo cdn_change_info = 13;
+    optional PlaybackModeChangeInfo playback_mode_change_info = 14;
+    optional NetworkChangeInfo network_change_info = 15;
   }
 
   // Device orientation info
@@ -108,6 +110,19 @@ message PlaybackEvent {
     optional string video_cdn = 1;
     optional string video_previous_cdn = 2;
   }
+
+  // Playback mode change info
+  message PlaybackModeChangeInfo {
+    optional string player_playback_mode = 1;
+    optional string player_playback_mode_data = 2;
+  }
+
+  // Network change info
+  message NetworkChangeInfo {
+    optional string viewer_connection_type = 1;
+    optional bool viewer_connection_low_data_mode = 2;
+  }
+
   required string id = 83;
   required string view_id = 1;
   optional int32 asn = 2;

--- a/video_view/README.md
+++ b/video_view/README.md
@@ -14,10 +14,17 @@ See our [Streaming Exports guide](https://docs.mux.com/guides/data/export-raw-vi
 
 As Mux Data adds new metrics, new versions of the protobuf specification are released. This repository always contains the most up-to-date specification. See our guide on [understanding the data fields](https://docs.mux.com/guides/data/export-raw-video-view-data#understand-the-data-fields) to see a full list of supported metrics.
 
+### Version 17
+
+Added new event metadata for `networkchange` events
+
 ### Version 16
 
-Added new rendition dimensions:
+Added new standard dimensions:
 
+- `view_rendition_change_count`
+- `view_rendition_upshift_count`
+- `view_rendition_downshift_count`
 - `player_height_initial`
 - `player_source_bitrate_initial`
 - `player_source_fps_initial`
@@ -28,18 +35,16 @@ Added new rendition dimensions:
 - `player_source_bitrate`
 - `player_source_fps`
 
-and new rendition metrics:
-
-- `view_rendition_change_count`
-- `view_rendition_upshift_count`
-- `view_rendition_downshift_count`
-
 ### Version 15
 
-Added new playing time metrics, with playing time calculated per playback mode and ad type:
+Added new standard dimensions:
 
+- `player_playback_mode`
+- `player_playback_mode_data`
 - `playback_mode_totals`
 - `ad_type_totals`
+
+Added new event metadata for `playbackmodechange` events
 
 ### Version 14
 

--- a/video_view/v1/video_view.proto
+++ b/video_view/v1/video_view.proto
@@ -93,6 +93,18 @@ message VideoView {
     optional string video_previous_cdn = 2;
   }
 
+  // Playback mode change info
+  message PlaybackModeChangeInfo {
+    optional string player_playback_mode = 1;
+    optional string player_playback_mode_data = 2;
+  }
+
+  // Network change info
+  message NetworkChangeInfo {
+    optional string viewer_connection_type = 1;
+    optional bool viewer_connection_low_data_mode = 2;
+  }
+
   message PlayingTimeInfo {
     optional int64 total_playing_time_ms = 1;
   }
@@ -111,6 +123,8 @@ message VideoView {
     optional RequestCanceledInfo request_canceled_info = 11;
     optional RequestCompletedInfo request_completed_info = 12;
     optional CdnChangeInfo cdn_change_info = 13;
+    optional PlaybackModeChangeInfo playback_mode_change_info = 14;
+    optional NetworkChangeInfo network_change_info = 15;
   }
 
   required string view_id = 1;
@@ -313,13 +327,13 @@ message VideoView {
   optional int32 view_rendition_change_count = 184; // The total number of rendition changes that occurred during playback, including both upshifts and downshifts in quality.
   optional int32 view_rendition_upshift_count = 185; // The number of times the video quality shifted upward to a higher quality rendition during playback.
   optional int32 view_rendition_downshift_count = 186; // The number of times the video quality shifted downward to a lower quality rendition during playback.
-  optional int32 player_height_initial = 187; // Initial height of the player (in pixels) as displayed on the screen.
-  optional int32 player_source_bitrate_initial = 188; // Initial bitrate of the source video.
-  optional float player_source_fps_initial = 189; // Initial framerate of the source video.
-  optional int32 player_width_initial = 190; // Initial width of the player (in pixels) as displayed on the screen.
-  optional string audio_codec_initial = 191; // Initial codec of the audio that played.
-  optional string video_codec_initial = 192; // Initial codec of the video that played.
-  optional string video_dynamic_range_type_initial = 193; // Initial format or type of dynamic range available on the video that played
+  optional int32 player_height_initial = 187; // Initial height (in pixels) of the source currently loaded in the player, regardless of the size of the player. Derived from the first value of the player_source_height dimension.
+  optional int32 player_source_bitrate_initial = 188; // Initial bitrate of the source video. Derived from the first value of the player_source_bitrate dimension.
+  optional float player_source_fps_initial = 189; // Initial framerate of the source video. Derived from the first value of the player_source_fps dimension.
+  optional int32 player_width_initial = 190; // Initial width (in pixels) of the source currently loaded in the player, regardless of the size of the player. Derived from the first value of the player_source_width dimension.
+  optional string audio_codec_initial = 191; // Initial codec of the audio that played. Derived from the first value of the audio_codec dimension.
+  optional string video_codec_initial = 192; // Initial codec of the video that played. Derived from the first value of the video_codec dimension.
+  optional string video_dynamic_range_type_initial = 193; // Initial format or type of dynamic range available on the video that played. Derived from the first value of the video_dynamic_range_type dimension.
   optional int32 player_source_bitrate = 194; // Bitrate of the source video.
   optional float player_source_fps = 195; // Framerate of the source video.
   reserved 200 to 299;


### PR DESCRIPTION
> [!NOTE]
> This was authored by @claude, not @jrmann100.

## Summary

- **V17**: `NetworkChangeInfo` and `PlaybackModeChangeInfo` event metadata messages + event fields in both `video_view` and `playback_event` protos
- **V16**: Improved field comments for initial rendition dimensions (187–193)
- **V15**: `player_playback_mode` and `player_playback_mode_data` dimensions added to README